### PR TITLE
Ignore virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@
 /build
 /dist
 /*.egg-info
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
## Description
Some developers prefer to not use pipenv ([source](https://chriswarrick.com/blog/2018/07/17/pipenv-promises-a-lot-delivers-very-little/#the-break-neck-pace-of-pipenv)). It is better to let them develop with their own environment tools.

## Motivation and Context
Pipenv is no longer recommended by PyPa. So it would be better to support the standard way of doing things. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
